### PR TITLE
ingress passthrough

### DIFF
--- a/upwork-devs/hanyhesham/README.md
+++ b/upwork-devs/hanyhesham/README.md
@@ -128,42 +128,13 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 
 # Apps deployment
 
-### Configure registry
-
-We are using github repo for this demo as a private registry.
-
-- Create a personal token with (_read:packages_, _write:packages_) permissions in your github account (Settings --> Developer settings --> personal access token)
- 
-- Log in to the repo using your GitHub Id and the token.
-
-` docker login docker.pkg.github.com` 
-
 ### Build Images
 
-Follow the guide in [k8-reverse-proxy](https://github.com/k8-proxy/k8-reverse-proxy/tree/develop/stable-src) to build ICAP and Squid images.
+The guide for building ICAP and Squid images could be found in [k8-reverse-proxy](https://github.com/k8-proxy/k8-reverse-proxy/tree/develop/stable-src).
 
-For the Nginx images, build the image from _nginx_ directory:
-
-```
-cd images/nginx
-docker build . -t nginx:v1 
-```
+Some issues occured during pods creation, I need to edit the Dockerfiles for Squid and Nginx images, you could check the new files in _images_ dir. 
 
 **Note: This step should be done using GitHub actions to automated the process of images build and push in the prodcution environment**
-
-
-### Fix Squid-ICAP problem
-
-Squid server fails to connect to ICAP server if hostname is used instead of IP, to fix this, we need to edit entrypoint in squid image.
-
-To build the new image:
-
-```
-cd images/squid
-docker build . -t squid-reverse:v1
-```
-
-**Note: This is a temporary solution to fix the issue, a PR should be requested in the [k8-reverse-proxy](https://github.com/k8-proxy/k8-reverse-proxy/tree/develop/stable-src) to edit the code.**
 
 ### Allow Ingress passthrough
 

--- a/upwork-devs/hanyhesham/README.md
+++ b/upwork-devs/hanyhesham/README.md
@@ -165,6 +165,26 @@ docker build . -t squid-reverse:v1
 
 **Note: This is a temporary solution to fix the issue, a PR should be requested in the [k8-reverse-proxy](https://github.com/k8-proxy/k8-reverse-proxy/tree/develop/stable-src) to edit the code.**
 
+### Allow Ingress passthrough
+
+- Edit ingress daemonset to add new argument:
+
+  `kubectl edit daemonset.apps/ingress-nginx-controller -n ingress-nginx`
+
+- Add `- --enable-ssl-passthrough` to `- args:`:
+
+```
+    spec:
+      containers:
+      - args:
+        - --enable-ssl-passthrough
+```
+
+- Wait until new pod is up and running:
+
+  `kubectl get pods -n ingress-nginx`
+
+
 ### Deploy apps manifests
 
 In order to deploy our stack to the K8s cluster, we need to apply some manifests as following:
@@ -178,6 +198,7 @@ kubectl create secret generic cert --from-file=./secrets/full.pem -n reverse-pro
 kubectl apply -f icap.yaml
 kubectl apply -f squid.yaml
 kubectl apply -f nginx.yaml
+kubectl apply -f ingress.yaml
 ```
 
 ### Test Application
@@ -188,13 +209,9 @@ kubectl apply -f nginx.yaml
 $k8s_node_ip gov.uk.glasswall-icap.com www.gov.uk.glasswall-icap.com assets.publishing.service.gov.uk.glasswall-icap.com
 ```
 
-- Open your browser and navigate to https://www.gov.uk.glasswall-icap.com:30900/
+- Open your browser and navigate to https://www.gov.uk.glasswall-icap.com
 
 
 ### Next Steps
-
-~~- Use Ingress for Nginx route.~~
-
-**Note: As discussed with Nouman, we will use nodeport in this phase**
 
 - Use Github actions for image creation.

--- a/upwork-devs/hanyhesham/k8s-manifests/icap.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/icap.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: icap
-        image: docker.pkg.github.com/hanyhesham/s-k8-proxy-rebuild/gw-icap:latest
+        image: hheshamrepo/gw-icap:v1 
         imagePullPolicy: "IfNotPresent"
 ---
 apiVersion: v1

--- a/upwork-devs/hanyhesham/k8s-manifests/ingress.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1 
+kind: Ingress
+metadata:
+  name: nginx-ingress
+  namespace: reverse-proxy
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+spec:
+  tls:
+  - hosts:
+      - gov.uk.glasswall-icap.com
+      - www.gov.uk.glasswall-icap.com
+  rules:
+  - host: www.gov.uk.glasswall-icap.com
+    http:
+      paths:
+      - pathType: ImplementationSpecific
+        path: /
+        backend:
+          service: 
+            name: nginx
+            port: 
+              number: 443

--- a/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx 
-        image: nginx:v1
+        image: hheshamrepo/nginx:v1 
         imagePullPolicy: "IfNotPresent"
         env:
           - name: ALLOWED_DOMAINS

--- a/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
@@ -20,11 +20,11 @@ spec:
         imagePullPolicy: "IfNotPresent"
         env:
           - name: ALLOWED_DOMAINS
-            value: gov.uk.glasswall-icap.com:30900,www.gov.uk.glasswall-icap.com:30900,assets.publishing.service.gov.uk.glasswall-icap.com:30900
+            value: gov.uk.glasswall-icap.com,www.gov.uk.glasswall-icap.com,assets.publishing.service.gov.uk.glasswall-icap.com
           - name: ICAP_URL
             value: icap://icap:1344/gw_rebuild
           - name: ROOT_DOMAIN
-            value: glasswall-icap.com:30900
+            value: glasswall-icap.com
         volumeMounts:
         - name: nginx-cert
           mountPath: "etc/nginx/certs"
@@ -53,7 +53,6 @@ metadata:
   name: nginx
   namespace: reverse-proxy
 spec:
-  type: NodePort
   selector:
     app: nginx
   ports:
@@ -61,7 +60,6 @@ spec:
     name: secured
     protocol: TCP
     targetPort: 443
-    nodePort: 30900
   - port: 80
     name: insecure
     protocol: TCP

--- a/upwork-devs/hanyhesham/k8s-manifests/secrets/entrypoint.sh
+++ b/upwork-devs/hanyhesham/k8s-manifests/secrets/entrypoint.sh
@@ -8,7 +8,7 @@ proxy_set_header Host \$host;
 proxy_set_header Connection \$connection;
 proxy_set_header X-Real-IP \$remote_addr;
 proxy_set_header Accept-Encoding "";
-proxy_pass http://127.0.0.1:8080;
+proxy_pass http://squid:8080;
 EOF
 
 for i in "${SUBFILTER[@]}" ;  do

--- a/upwork-devs/hanyhesham/k8s-manifests/secrets/subfilter.sh
+++ b/upwork-devs/hanyhesham/k8s-manifests/secrets/subfilter.sh
@@ -1,1 +1,1 @@
-SUBFILTER=( .gov.uk,.gov.uk.glasswall-icap.com:30900  .amazonaws.com,.amazonaws.com.glasswall-icap.com:30900 )
+SUBFILTER=( .gov.uk,.gov.uk.glasswall-icap.com  .amazonaws.com,.amazonaws.com.glasswall-icap.com )

--- a/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
@@ -34,7 +34,6 @@ metadata:
   name: squid
   namespace: reverse-proxy
 spec:
-  type: NodePort
   selector:
     app: squid
   ports:

--- a/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: squid 
-        image: squid-reverse:v1
+        image: hheshamrepo/squid-reverse:v1
         imagePullPolicy: "IfNotPresent"
         env:
           - name: ALLOWED_DOMAINS


### PR DESCRIPTION
To allow URL access without a port (nodeport), I allowed ingress passthrough and forced SSL redirection, I kept the SSL termination at the pod level (full.pem).

This is the simplest way to keep the current setup and integrate it with K8s.

There are two other options that I will investigate later after finishing the whole cycle (automate image creation):

1- Try to convert all the Nginx entrypoint actions to annotations that could be added to the ingress manifest.

e.g of the entrypoint:

for i in "${SUBFILTER[@]}" ;  do
    IFS="," ; set -- $i
    echo "sub_filter '$1' '$2' ;"  >> /etc/nginx/conf.d/default.conf
done

2- If not applicable, I will use a custom dockerfile for the ingress to add the local Nginx entrypoint to it.