### PR TITLE
revert back to Github - kubespray

### DIFF
--- a/upwork-devs/hanyhesham/README.md
+++ b/upwork-devs/hanyhesham/README.md
@@ -158,6 +158,12 @@ Some issues occured during pods creation, I need to edit the Dockerfiles for Squ
 
 ### Deploy apps manifests
 
+
+We need to create a secret for github packages login as following:
+
+`kubectl create secret docker-registry regcred --docker-server=docker.pkg.github.com --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+`
+
 In order to deploy our stack to the K8s cluster, we need to apply some manifests as following:
 
 ```

--- a/upwork-devs/hanyhesham/k8s-manifests/icap.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/icap.yaml
@@ -16,8 +16,10 @@ spec:
     spec:
       containers:
       - name: icap
-        image: hheshamrepo/gw-icap:v1 
+        image: docker.pkg.github.com/hanyhesham/s-k8-proxy-rebuild/gw-icap:v1 
         imagePullPolicy: "IfNotPresent"
+      imagePullSecrets:
+      - name: regcred
 ---
 apiVersion: v1
 kind: Service

--- a/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/nginx.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx 
-        image: hheshamrepo/nginx:v1 
+        image: docker.pkg.github.com/hanyhesham/s-k8-proxy-rebuild/nginx:v1 
         imagePullPolicy: "IfNotPresent"
         env:
           - name: ALLOWED_DOMAINS
@@ -35,6 +35,8 @@ spec:
         - name: subfilter
           mountPath: "/subfilter/"
           readOnly: true
+      imagePullSecrets:
+      - name: regcred
       volumes:
       - name: nginx-cert
         secret:

--- a/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
+++ b/upwork-devs/hanyhesham/k8s-manifests/squid.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: squid 
-        image: hheshamrepo/squid-reverse:v1
+        image: docker.pkg.github.com/hanyhesham/s-k8-proxy-rebuild/squid-reverse:v1 
         imagePullPolicy: "IfNotPresent"
         env:
           - name: ALLOWED_DOMAINS
@@ -27,6 +27,8 @@ spec:
             value: glasswall-icap.com
           - name: ICAP_PORT
             value: "1344"
+      imagePullSecrets:
+      - name: regcred
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Revert back to GitHub packages instead of DockerHub as required by GW.